### PR TITLE
modified:   Dockerfile. Result - Redusing the image file size twice

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,16 +13,24 @@ ENV DB_USER=sopds \
     MIGRATE=False \
     VERSION=0.47
 
-RUN apk add --no-cache -U tzdata bash nano build-base libxml2-dev libxslt-dev unzip postgresql postgresql-dev libffi-dev libc-dev jpeg-dev zlib-dev
-RUN cp /usr/share/zoneinfo/Europe/Moscow /etc/localtime
-RUN echo "Europe/Moscow" > /etc/timezone
-RUN apk del tzdata
+ADD requirements.txt /requirements.txt
 ADD https://github.com/mitshel/sopds/archive/master.zip /sopds.zip
-RUN unzip sopds.zip && rm sopds.zip && mv sopds-* sopds
-ADD configs/settings.py /sopds/sopds/settings.py
-ADD requirements.txt /sopds/requirements.txt
+RUN apk add --no-cache -U tzdata unzip build-base libxml2-dev libxslt-dev postgresql-dev libffi-dev libc-dev jpeg-dev zlib-dev \
+&& cp /usr/share/zoneinfo/Europe/Moscow /etc/localtime \
+&& echo "Europe/Moscow" > /etc/timezone \
+&& unzip sopds.zip \
+&& rm sopds.zip \
+&& mv sopds-* sopds \
+&& mv /requirements.txt /sopds/requirements.txt \
+&& cd /sopds \
+&& pip3 install --upgrade pip setuptools psycopg2-binary \
+&& pip3 install --upgrade -r requirements.txt \
+&& apk del tzdata unzip build-base libxml2-dev libxslt-dev postgresql-dev libffi-dev libc-dev jpeg-dev zlib-dev \
+&& apk add --no-cache -U bash libxml2 libxslt libffi libjpeg zlib postgresql \
+&& rm -rf /root/.cache/ \
+&& cd /
 WORKDIR /sopds
-RUN pip3 install --upgrade pip setuptools psycopg2-binary && pip3 install --upgrade -r requirements.txt
+ADD configs/settings.py /sopds/sopds/settings.py
 ADD scripts/start.sh /start.sh
 RUN chmod +x /start.sh
 


### PR DESCRIPTION
[*] Redusing the image file size twice due to combine all actions
    related to compile in one RUN stage, and removing the *-dev
    packages from the rusulting image.
      zveronline/sopds latest 664MB
      newlybuild/sopds latest 272MB