### PR TITLE
Auto creation the superuser on the first run - adopted to last changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ ENV DB_USER=sopds \
     SOPDS_ROOT_LIB="/library" \
     SOPDS_INPX_ENABLE=True \
     SOPDS_LANGUAGE=ru-RU \
+    SOPDS_SU_NAME="admin" \
+    SOPDS_SU_EMAIL="admin@localhost" \
+    SOPDS_SU_PASS="admin" \
     MIGRATE=False \
     VERSION=0.47
 
@@ -31,6 +34,10 @@ RUN apk add --no-cache -U tzdata unzip build-base libxml2-dev libxslt-dev postgr
 && cd /
 WORKDIR /sopds
 ADD configs/settings.py /sopds/sopds/settings.py
+#add autocreation of the superuser
+RUN apk add --no-cache -U expect
+ADD scripts/superuser.exp /sopds/superuser.exp
+#
 ADD scripts/start.sh /start.sh
 RUN chmod +x /start.sh
 

--- a/README.md
+++ b/README.md
@@ -59,9 +59,16 @@ docker run --name sopds -d \
 
 # Create superuser
 
+By default the superuser will be created with predefined name "admin" and password "admin". But you can manage it via appropriate environmental variables:
 ```bash
-docker exec -ti sopds bash
-python3 manage.py createsuperuser
+docker run --name sopds -d \
+   --volume /path/to/library:/library:ro \
+   --volume /path/to/database:/var/lib/pgsql \
+   --env 'SOPDS_SU_NAME="your_name_for_superuser"' \
+   --env 'SOPDS_SU_EMAIL='"your_mail_for_superuser@your_domain"' \
+   --env 'SOPDS_SU_PASS="your_password_for_superuser"' \
+   --publish 8081:8001 \
+   zveronline/sopds
 ```
 
 # Scan library

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -46,6 +46,12 @@ then
 python3 manage.py sopds_util setconf SOPDS_ROOT_LIB $SOPDS_ROOT_LIB
 python3 manage.py sopds_util setconf SOPDS_INPX_ENABLE $SOPDS_INPX_ENABLE
 python3 manage.py sopds_util setconf SOPDS_LANGUAGE $SOPDS_LANGUAGE
+#autocreate the superuser
+if [[ ! -z $SOPDS_SU_NAME && ! -z $SOPDS_SU_EMAIL &&  ! -z $SOPDS_SU_PASS ]]
+then
+expect /sopds/superuser.exp
+fi
+#
 touch /var/lib/pgsql/setconf
 fi
 python3 manage.py sopds_server start & python3 manage.py sopds_scanner start

--- a/scripts/superuser.exp
+++ b/scripts/superuser.exp
@@ -1,0 +1,24 @@
+#!/usr/bin/expect -f
+set timeout -1
+spawn python3 manage.py createsuperuser
+match_max 100000
+expect -nocase "username*: "
+send -- "$env(SOPDS_SU_NAME)\r"
+expect {
+    -nocase "email address: " {
+	send -- "$env(SOPDS_SU_EMAIL)\r"
+	expect -nocase "password*: "
+	send -- "$env(SOPDS_SU_PASS)\r"
+	expect -nocase "password*: "
+	send -- "$env(SOPDS_SU_PASS)\r"
+	expect {
+	    -nocase "*create user anyway?*: " {
+		send -- "y\r"
+		exp_continue
+	    }
+	}
+    }
+    -nocase "username is already taken" {
+	exit
+    }
+}


### PR DESCRIPTION
[+] Auto creation the superuser on the first run based on the new
    environmental variables:
    SOPDS_SU_NAME, defail value "admin"
    SOPDS_SU_EMAIL, default value "admin@localhost"
    SOPDS_SU_PASS, default value "admin".
    Executed only on first start. Variables can be cleared after.
 Changes to be committed:
	modified:   Dockerfile
	modified:   README.md
	modified:   scripts/start.sh
	new file:   scripts/superuser.exp