### PR TITLE
Fix database connection isn't set to UTC, when psycopg2 v2.9 work with old Django

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN apk add --no-cache -U tzdata unzip build-base libxml2-dev libxslt-dev postgr
 && mv /requirements.txt /sopds/requirements.txt \
 && mv /settings.py /sopds/sopds/settings.py \
 && cd /sopds \
-&& pip3 install --upgrade pip setuptools psycopg2-binary \
+&& pip3 install --upgrade pip setuptools 'psycopg2-binary>=2.8,<2.9' \
 && pip3 install --upgrade -r requirements.txt \
 && unzip /fb2c_linux_i386.zip -d /sopds/convert/fb2c/  \
 && rm /fb2c_linux_i386.zip \


### PR DESCRIPTION
Based on 
[AssertionError: database connection isn't set to UTC](https://stackoverflow.com/questions/68024060/assertionerror-database-connection-isnt-set-to-utc)