### PR TITLE
fix convert file with spaces

### DIFF
--- a/scripts/fb2conv
+++ b/scripts/fb2conv
@@ -22,10 +22,10 @@ run_path=$(dirname $(realpath ${0}))
 converter="${run_path}/fb2c"
 
 if [ ! -z "${1}" ]; then
-    if  [ -f ${1} ] ; then
+    if  [ -f "${1}" ] ; then
 	if [ ! -z "${2}" ] ; then
 	    tmp_path=$(dirname $(realpath ${2}))
-	    tmp_name=$(basename ${1} | sed s/\.${in_format}$/\.${out_format}/)
+	    tmp_name=$(basename "${1}" | sed s/\.${in_format}$/\.${out_format}/)
 	    if [ -d ${tmp_path} ] ; then
 		if [ -x ${converter} ] ; then
 		    echo "$(date +"%Y-%m-%dT%T.000%z")    INFO    Starting converstion from ${1} to ${2} via ${tmp_path}/${tmp_name}, by ${converter}:" >> ${CONV_LOG}
@@ -36,7 +36,7 @@ if [ ! -z "${1}" ]; then
 		    $converter --config ${run_path}/configuration.toml convert -to ${out_format} "${1}" "${tmp_path}" >> ${CONV_LOG} 
 		    if [ -f "${tmp_path}/${tmp_name}" ]; then
 			echo "$(date +"%Y-%m-%dT%T.000%z")    INFO    Converted temporary file  ${tmp_path}/${tmp_name} is found! Renaming to  ${2} ..." >> ${CONV_LOG}
-			mv -f ${tmp_path}/${tmp_name} ${2}  >> ${CONV_LOG} 2>&1 || exit 1
+			mv -f "${tmp_path}/${tmp_name}" ${2}  >> ${CONV_LOG} 2>&1 || exit 1
 			echo "$(date +"%Y-%m-%dT%T.000%z")    INFO    Done!" >> ${CONV_LOG}
 			exit 0
 		    else


### PR DESCRIPTION
When trying to download a book in mobi or epub formats, if there are spaces in the book name, a 404 error was returned.

There were errors in the logs:

-  Source file /library/ри/ричард матесон - последний день.fb2 not found!
- Destination file  is not defined!
- mv: can't rename '/sopds/tmp/ричард': No such file or directory
mv: can't rename 'матесон': No such file or directory
mv: can't rename '-': No such file or directory
mv: can't rename 'последний': No such file or directory
mv: can't rename 'день.mobi': No such file or directory