### PR TITLE
Bugfix "PytzUsageWarning: The zone attribute is specific to pytz's in…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ apscheduler>=3.3.0
 django-picklefield
 lxml
 python-telegram-bot>=10
+tzlocal==2.1


### PR DESCRIPTION
Bugfix with "PytzUsageWarning: The zone attribute is specific to pytz's interface; please migrate to a new time zone provider"

![sopds](https://user-images.githubusercontent.com/35106026/159188668-85799aee-9667-42ac-8e90-3d7a80c2216e.jpg)
